### PR TITLE
Classes map must contains type actual names in keys, not original ones

### DIFF
--- a/lib/json_mapper.dart
+++ b/lib/json_mapper.dart
@@ -68,7 +68,7 @@ class JsonMapper {
 
   JsonMapper._internal() {
     for (ClassMirror classMirror in serializable.annotatedClasses) {
-      classes[classMirror.simpleName] = classMirror;
+      classes[classMirror.reflectedType.toString()] = classMirror;
     }
     registerDefaultConverters();
     registerDefaultValueDecorators();


### PR DESCRIPTION
When compiled with dart2js with minification, class names are different from original, so we use them as keys. Unfortunately I didn't find better method than to use reflectedType.toString().
It will solve issue #13